### PR TITLE
The docker apt repository is no longer at http://get.docker.io/ubuntu…

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -6,13 +6,18 @@
 - name: Add specific key
   command: apt-key adv --keyserver keyserver.ubuntu.com --recv-keys {{docker_repo_key}}
 
+- name: Update
+  command: apt-get update
+
+- name: Install https apt transport package
+  command: apt-get install -y apt-transport-https
+
 - name: Add docker repo
   command: sudo sh -c "echo deb {{docker_repo}} docker main > /etc/apt/sources.list.d/docker.list"
 
-- name: Install os packages
+- name: Install lxc-docker package
   apt: pkg={{item}} state=present update_cache=yes
-  with_items: 
-    - linux-image-extra-{{os_uname.stdout}}
+  with_items:
     - lxc-docker
 
 - name: Docker default config file

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@ docker_playbook_version: "0.1.2"
 
 # replace with gist variant
 docker_repo_key: "36A1D7869245C8950F966E92D8576A8BA88D21E9"
-docker_repo: "http://get.docker.io/ubuntu"
+docker_repo: "https://get.docker.io/ubuntu"
 docker_opts: ''
 
 ##### ---


### PR DESCRIPTION
… (should be https), BUT apt-transport-https must be installed to use it. Also, GCE VMs weren't able to find the linux-image-extra package for their kernel version, which is why I removed that line.
