### PR TITLE
systemd service start timeout configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,40 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.ssh.forward_agent = true
+  config.vm.synced_folder Dir.getwd, "/home/vagrant/roles/ansible-docker", nfs: true
+
+  # ubuntu 12.04 that Travis CI is using
+  config.vm.define 'travis', primary: true do |c|
+    c.vm.network "private_network", ip: "192.168.100.2"
+    c.vm.box = "precise-server-cloudimg-amd64-vagrant-disk1"
+    c.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/precise/current/precise-server-cloudimg-amd64-vagrant-disk1.box"
+    c.vm.provision "shell" do |s|
+      s.inline = "apt-get update -y; apt-get install python-software-properties; add-apt-repository ppa:rquillo/ansible; apt-get update -y; apt-get install ansible -y"
+      s.privileged = true
+    end
+  end
+
+  # ubuntu 14.04
+  config.vm.define 'ubuntu', primary: true do |c|
+    c.vm.network "private_network", ip: "192.168.100.3"
+    c.vm.box = "trusty-server-cloudimg-amd64-vagrant-disk1"
+    c.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+    c.vm.provision "shell" do |s|
+      s.inline = "apt-get update -y; apt-get install -y software-properties-common; apt-add-repository ppa:ansible/ansible; apt-get update -y; apt-get install -y ansible"
+      s.privileged = true
+    end
+  end
+
+  # centos 7:
+  config.vm.define 'centos7' do |c|
+    c.vm.network "private_network", ip: "192.168.100.5"
+    c.vm.box = "centos/7"
+    c.vm.provision "shell" do |s|
+      s.inline = "yum install -y epel-release; yum install -y ansible"
+      s.privileged = true
+    end
+  end
+
+end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ docker_playbook_version: "0.1.2"
 
 docker_opts: ''
 docker_create_group: true
+docker_service_start_timeout: ''    # use system default value
 
 ##### ---
 # Want to advertise the tcp port? Enable below.

--- a/templates/docker-service.j2
+++ b/templates/docker-service.j2
@@ -10,6 +10,9 @@ Requires=docker.socket
 Type=notify
 EnvironmentFile=-/etc/sysconfig/docker
 ExecStart=/usr/bin/docker -d -H fd:// $OPTIONS
+{% if docker_service_start_timeout != '' %}
+TimeoutStartSec={{ docker_service_start_timeout }}
+{% endif %}
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
Some machine are too busy or slow and Docker service is taking longer than default 90 seconds on CentOS 7 to start. System then just kill the process. Add an optional configuration to set the start time out.

Didn't find equivalent with upstart/init .
