### PR TITLE
Update repo URL for RedHat flavoured distributions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # RedHat: Docker yum repository URL
-docker_yum_repo: "https://yum.dockerproject.org/repo/main/{{ ansible_distribution | lower }}/{{ os_version_major }}"
+docker_yum_repo: "https://yum.dockerproject.org/repo/main/centos/$releasever/"
 docker_yum_repo_gpg: 'https://yum.dockerproject.org/gpg'
 
 docker_opts: ''


### PR DESCRIPTION
The URL for the repo in https://docs.docker.com/engine/installation/centos/ is a different one. I get an error with the one originally in this playbook. I added the one from the website and now it works. Sorry for the fuzzy description...
